### PR TITLE
add feature flags system for V1.0 segmentation

### DIFF
--- a/front-client/app/(pro)/_layout.tsx
+++ b/front-client/app/(pro)/_layout.tsx
@@ -6,6 +6,7 @@ import Ionicons from "@expo/vector-icons/Ionicons";
 import { SafeAreaView } from "react-native-safe-area-context";
 import BackButton from '@/components/BackButton';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+import { isEnabled } from '@/config/featureFlags';
 const Date= require('@/assets/images/Consultation/Date.svg');
 
 /**
@@ -99,15 +100,16 @@ const ProLayout = () => {
             }}
           />
 
-          {/* Messages */}
+          {/* Messages — masqué V1.0 (UI mock, backend non finalisé) */}
           <Tabs.Screen
             name="messages"
-            options={{
+            options={isEnabled('proMessaging') ? {
               title: "Messages",
               tabBarIcon: ({ color, focused }) => (
                 <MaterialCommunityIcons name={focused ? "message-badge" : "message-badge-outline"} size={22} color={color} />
-                
               ),
+            } : {
+              href: null,
             }}
           />
 

--- a/front-client/app/(tabs)/_layout.tsx
+++ b/front-client/app/(tabs)/_layout.tsx
@@ -18,6 +18,7 @@ import Fontisto from '@expo/vector-icons/Fontisto';
 import AntDesign from '@expo/vector-icons/AntDesign';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { useAuth } from '../../context/AuthContext';
+import { isEnabled } from '@/config/featureFlags';
 
 // Liste des tabs avec leurs informations
 const TAB_ITEMS = [
@@ -71,6 +72,7 @@ export default function TabLayout() {
               }
 
               if (name === 'my-space') {
+                if (!isEnabled('asyncConsultation')) return null;
                 return (
                   <TouchableOpacity
                     onPress={() => router.push('/teleconsultation/async-request')}
@@ -107,9 +109,8 @@ export default function TabLayout() {
     borderRadius: 25,
 
             freezeOnBlur: true,
-          
-            // custom button wrapper
-          tabBarButton: props => {
+
+            tabBarButton: props => {
             const { accessibilityState, style, children, onPress,  delayLongPress, testID } = props;
             const focused = accessibilityState?.selected ?? false;
             return (
@@ -129,6 +130,9 @@ export default function TabLayout() {
           },
           };
         }}>
+
+        {/* Masquer l'onglet settings du tab bar — accessible via router.push si besoin */}
+        <Tabs.Screen name="settings" options={{ href: null }} />
 
         {TAB_ITEMS.map((tab) => (
           <Tabs.Screen

--- a/front-client/app/(tabs)/my-space.tsx
+++ b/front-client/app/(tabs)/my-space.tsx
@@ -10,6 +10,7 @@ import { useAuth } from '@/context/AuthContext';
 import useAppointments from '@/hooks/useAppointments'; // Import the hook
 import NextMeetingCard from '@/components/NextMeetingCard';
 import api from '@/services/api';
+import { isEnabled } from '@/config/featureFlags';
 
 export default function MySpace() {
   const router = useRouter();
@@ -29,50 +30,54 @@ export default function MySpace() {
   return (
     <View style={styles.container}>
       <View style={{ flex: 1, marginTop: 0, justifyContent: 'flex-start' }}>
-        <Text style={[styles.subtitle, { paddingHorizontal: 6, marginBottom: 25 }]}>Mon prochain rendez-vous</Text>
-        {loading ? (
-          <Text>Chargement...</Text>
-        ) : isMeeting && nextAppointment && nextAppointment.practitionerProfile ? (
-          <NextMeetingCard
-            isMeeting={!isMeeting}
-            date={new Date(nextAppointment.start_at).toLocaleDateString('fr-FR', { day: '2-digit', month: 'long', year: 'numeric' })}
-            time={new Date(nextAppointment.start_at).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })}
-            item={{
-              id: nextAppointment.id,
-              imageUrl: 'https://images.unsplash.com/photo-1633332755192-727a05c4013d', // Placeholder, replace with actual image URL if available
-              location: nextAppointment.practitionerProfile.city,
-              name: nextAppointment.practitionerProfile.user?.userName || 'N/A',
-              specialty: nextAppointment.practitionerProfile.specialties.join(', '),
-            }}
-            reason={nextAppointment.notes || ''}
-            onCancel={handleCancel}
-          />
-        ) : (
-          <Text>Aucun rendez-vous à venir.</Text>
-        )}
-        
-         <Text style={[styles.subtitle, { paddingHorizontal: 5,  paddingVertical: 16, marginTop: 20}]}>Consulter</Text>
-        <TouchableOpacity
-          activeOpacity={0.85}
-          style={styles.buttonShadow}
-          onPress={() =>
-            router.push({
-              pathname: '/teleconsultation/pro-list',
-              params: { article: 5 },
-            })
-          }
-        >
-          <LinearGradient
-            colors={['#39df87', '#6ee7b7']}
-            start={{ x: 0, y: 0 }}
-            end={{ x: 1, y: 1 }}
-            style={styles.button}
-          >
-            <Text style={styles.buttonText}>Téléconsultation</Text>
-          </LinearGradient>
-        </TouchableOpacity>
+        {isEnabled('teleconsultation') && (
+          <>
+            <Text style={[styles.subtitle, { paddingHorizontal: 6, marginBottom: 25 }]}>Mon prochain rendez-vous</Text>
+            {loading ? (
+              <Text>Chargement...</Text>
+            ) : isMeeting && nextAppointment && nextAppointment.practitionerProfile ? (
+              <NextMeetingCard
+                isMeeting={!isMeeting}
+                date={new Date(nextAppointment.start_at).toLocaleDateString('fr-FR', { day: '2-digit', month: 'long', year: 'numeric' })}
+                time={new Date(nextAppointment.start_at).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })}
+                item={{
+                  id: nextAppointment.id,
+                  imageUrl: 'https://images.unsplash.com/photo-1633332755192-727a05c4013d',
+                  location: nextAppointment.practitionerProfile.city,
+                  name: nextAppointment.practitionerProfile.user?.userName || 'N/A',
+                  specialty: nextAppointment.practitionerProfile.specialties.join(', '),
+                }}
+                reason={nextAppointment.notes || ''}
+                onCancel={handleCancel}
+              />
+            ) : (
+              <Text>Aucun rendez-vous à venir.</Text>
+            )}
 
-       <Text style={[styles.subtitle, { paddingHorizontal: 5, marginTop: 20}]}>En savoir plus</Text>
+            <Text style={[styles.subtitle, { paddingHorizontal: 5, paddingVertical: 16, marginTop: 20 }]}>Consulter</Text>
+            <TouchableOpacity
+              activeOpacity={0.85}
+              style={styles.buttonShadow}
+              onPress={() =>
+                router.push({
+                  pathname: '/teleconsultation/pro-list',
+                  params: { article: 5 },
+                })
+              }
+            >
+              <LinearGradient
+                colors={['#39df87', '#6ee7b7']}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 1 }}
+                style={styles.button}
+              >
+                <Text style={styles.buttonText}>Téléconsultation</Text>
+              </LinearGradient>
+            </TouchableOpacity>
+          </>
+        )}
+
+       <Text style={[styles.subtitle, { paddingHorizontal: 5, marginTop: isEnabled('teleconsultation') ? 20 : 0 }]}>En savoir plus</Text>
         <TouchableOpacity
           activeOpacity={0.85}
           style={[styles.buttonShadow, { marginTop: 28 }]}

--- a/front-client/config/featureFlags.ts
+++ b/front-client/config/featureFlags.ts
@@ -1,0 +1,44 @@
+/**
+ * BackRelief — Feature Flags
+ *
+ * Source de vérité unique pour la disponibilité publique de chaque fonctionnalité.
+ * Passer un flag à `true` expose la feature ; `false` la masque de l'UI.
+ *
+ * IMPORTANT : ce fichier contrôle uniquement l'UI (couche de présentation).
+ * Les features premium nécessiteront en plus un guard backend (PlanGuard) côté API.
+ *
+ * Sections :
+ *   V1.0 OPEN       — ouvertes au public dès le lancement
+ *   V1.0 HIDDEN     — développées mais non exposées pour le lancement
+ *   FUTUR PREMIUM   — réservées au modèle freemium (V1.5+)
+ */
+
+export const FEATURES = {
+  // ─── V1.0 OPEN ─────────────────────────────────────────────────────────────
+  home: true,
+  exerciseLibrary: true,
+  painTracking: true,
+  hydrationTracking: true,
+  healthStats: true,
+  reminders: true,
+  contentCatalog: true,   // articles statiques (validés médicalement)
+
+  proDashboard: true,
+  proAgenda: true,
+  proProfile: true,
+
+  // ─── V1.0 HIDDEN ───────────────────────────────────────────────────────────
+  // Passer à `true` pour exposer au public (pas de recompilation nécessaire).
+  teleconsultation: false,      // attente : RGPD + disponibilité praticiens
+  asyncConsultation: false,     // dépend de la téléconsultation
+  proMessaging: false,          // UI mock — backend non finalisé
+
+  // ─── FUTUR PREMIUM (V1.5+) ─────────────────────────────────────────────────
+  advancedAnalytics: false,
+  unlimitedPrograms: false,
+} as const;
+
+export type Feature = keyof typeof FEATURES;
+
+/** Retourne `true` si la feature est activée. */
+export const isEnabled = (feature: Feature): boolean => FEATURES[feature];


### PR DESCRIPTION
Introduce a central feature flags configuration (config/featureFlags.ts) as the single source of truth for feature availability at launch.

- teleconsultation, asyncConsultation, proMessaging hidden for V1.0
- my-space tab shows only the articles section when teleconsultation is off
- async-request header button gated behind asyncConsultation flag
- pro Messages tab hidden from tab bar via href:null (proMessaging flag)
- settings tab explicitly hidden from tab bar with href:null
- advancedAnalytics and unlimitedPrograms reserved for freemium V1.5+

Flipping any flag to `true` in featureFlags.ts is all it takes to open a feature — no further code changes needed.